### PR TITLE
Add SideStore deep link routing via /open endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sidestoreio",
   "version": "1.2.0",
   "description": "The sidestore website, visible at sidestore.io",
-  "source": "src/index.html",
+  "source": ["src/index.html", "src/open/index.html"],
   "license": "MIT",
   "scripts": {
     "dev": "node tools/update_apps.mjs && parcel",

--- a/src/open/index.html
+++ b/src/open/index.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Opening SideStore...</title>
+  
+  <link href="../assets/favicon-32x32.png" rel="icon" sizes="32x32" />
+  <link rel="icon" href="../assets/favicon.svg" type="image/svg+xml" />
+  <link href="../assets/apple-touch-icon.png" rel="apple-touch-icon" />
+  
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="../index.css" />
+  
+  <style>
+    body {
+      font-family: 'SatoshiVariable', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: radial-gradient(circle 120vh at 25% -20px, rgba(90, 26, 229, 0.15), rgba(90, 26, 229, 0.15), transparent),
+        radial-gradient(circle 150vh at 70% 80%, rgba(26, 80, 229, 0.15), transparent), #121316;
+      color: #fff;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      height: 100vh;
+      margin: 0;
+      text-align: center;
+    }
+    .container {
+      background: rgba(31, 32, 35, 0.8);
+      backdrop-filter: blur(32px);
+      border: 1px solid rgb(39 39 42);
+      border-radius: 1rem;
+      padding: 2rem;
+      max-width: 400px;
+      width: 90%;
+    }
+    .spinner {
+      border: 3px solid rgb(39 39 42);
+      border-top: 3px solid rgb(150 112 233);
+      border-radius: 50%;
+      width: 40px;
+      height: 40px;
+      animation: spin 1s linear infinite;
+      margin: 0 auto 20px auto;
+    }
+    @keyframes spin {
+      0% { transform: rotate(0deg); }
+      100% { transform: rotate(360deg); }
+    }
+    .message {
+      font-size: 1.125rem;
+      font-weight: 600;
+      margin-bottom: 1rem;
+      color: rgb(244 244 245);
+    }
+    .fallback {
+      margin-top: 1.5rem;
+      font-size: 0.875rem;
+      color: rgb(161 161 170);
+    }
+    .fallback a {
+      color: rgb(150 112 233);
+      text-decoration: none;
+      transition: color 0.2s ease;
+    }
+    .fallback a:hover {
+      color: rgb(196 181 253);
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="spinner"></div>
+    <div class="message">Opening SideStore...</div>
+    <div class="fallback">
+      <p><a href="/" id="home-link">Return to homepage</a></p>
+    </div>
+  </div>
+
+  <script>
+    // Add immediate visual feedback
+    document.addEventListener('DOMContentLoaded', function() {
+      console.log('SideStore Open: DOM loaded, script executing');
+      
+      // Handle /open routing with different parameters
+      const searchParams = new URLSearchParams(window.location.search);
+      const messageElement = document.querySelector('.message');
+      
+      console.log('SideStore Open Page: Processing URL parameters', Object.fromEntries(searchParams));
+      console.log('SideStore Open: Current URL:', window.location.href);
+      
+      // Add a small delay to allow logs to be visible and add visual feedback
+      const executeWithDelay = (action, delay = 500) => {
+        console.log(`SideStore Open: Will execute action in ${delay}ms`);
+        setTimeout(action, delay);
+      };
+      
+      // Check for 'source' parameter
+      if (searchParams.has('source')) {
+        const sourceUrl = searchParams.get('source');
+        const sidestoreUrl = `sidestore://source?url=${encodeURIComponent(sourceUrl)}`;
+        
+        console.log('SideStore Open: Source parameter detected', {
+          originalUrl: sourceUrl,
+          sidestoreUrl: sidestoreUrl
+        });
+        
+        messageElement.textContent = 'Opening source in SideStore...';
+        
+        console.log('SideStore Open: Executing redirect to sidestore://source');
+        
+        // Update address bar to show homepage URL
+        window.history.replaceState({}, '', '/');
+        
+        // Attempt to redirect to the sidestore:// URL immediately
+        window.location.href = sidestoreUrl;
+        
+        // Fallback: redirect to homepage after 3 seconds if sidestore:// doesn't work
+        setTimeout(() => {
+          console.log('SideStore Open: Fallback timeout reached, redirecting to homepage');
+          window.location.replace('/');
+        }, 3000);
+      } 
+      // Check for 'ipa' parameter
+      else if (searchParams.has('ipa')) {
+        const ipaUrl = searchParams.get('ipa');
+        
+        console.log('SideStore Open: IPA parameter detected', { ipaUrl: ipaUrl });
+        
+        // Check if the URL ends with .ipa extension
+        if (ipaUrl.toLowerCase().endsWith('.ipa')) {
+          const sidestoreUrl = `sidestore://install?url=${encodeURIComponent(ipaUrl)}`;
+          
+          console.log('SideStore Open: Valid IPA URL, redirecting', {
+            originalUrl: ipaUrl,
+            sidestoreUrl: sidestoreUrl
+          });
+          
+          messageElement.textContent = 'Installing IPA in SideStore...';
+          
+          console.log('SideStore Open: Executing redirect to sidestore://install');
+          
+          // Update address bar to show homepage URL
+          window.history.replaceState({}, '', '/');
+          
+          // Attempt to redirect to the sidestore:// URL immediately
+          window.location.href = sidestoreUrl;
+          
+          // Fallback: redirect to homepage after 3 seconds if sidestore:// doesn't work
+          setTimeout(() => {
+            console.log('SideStore Open: Fallback timeout reached, redirecting to homepage');
+            window.location.replace('/');
+          }, 3000);
+        } else {
+          // Invalid .ipa URL (doesn't end with .ipa), redirect to homepage
+          console.log('SideStore Open: Invalid IPA URL (no .ipa extension), redirecting to homepage', { ipaUrl: ipaUrl });
+          messageElement.textContent = 'Invalid IPA URL, redirecting...';
+          
+          executeWithDelay(() => {
+            console.log('SideStore Open: Executing redirect to homepage (invalid IPA)');
+            window.location.replace('/');
+          });
+        }
+      } 
+      // No valid parameters provided, redirect to homepage
+      else {
+        console.log('SideStore Open: No valid parameters found, redirecting to homepage');
+        messageElement.textContent = 'No valid parameters, redirecting...';
+        
+        executeWithDelay(() => {
+          console.log('SideStore Open: Executing redirect to homepage (no params)');
+          window.location.replace('/');
+        });
+      }
+    });
+  </script>
+</body>
+</html>

--- a/src/open/index.html
+++ b/src/open/index.html
@@ -1,18 +1,19 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Opening SideStore...</title>
-  
+
   <link href="../assets/favicon-32x32.png" rel="icon" sizes="32x32" />
   <link rel="icon" href="../assets/favicon.svg" type="image/svg+xml" />
   <link href="../assets/apple-touch-icon.png" rel="apple-touch-icon" />
-  
+
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="../index.css" />
-  
+
   <style>
     body {
       font-family: 'SatoshiVariable', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
@@ -27,6 +28,7 @@
       margin: 0;
       text-align: center;
     }
+
     .container {
       background: rgba(31, 32, 35, 0.8);
       backdrop-filter: blur(32px);
@@ -36,6 +38,7 @@
       max-width: 400px;
       width: 90%;
     }
+
     .spinner {
       border: 3px solid rgb(39 39 42);
       border-top: 3px solid rgb(150 112 233);
@@ -45,31 +48,42 @@
       animation: spin 1s linear infinite;
       margin: 0 auto 20px auto;
     }
+
     @keyframes spin {
-      0% { transform: rotate(0deg); }
-      100% { transform: rotate(360deg); }
+      0% {
+        transform: rotate(0deg);
+      }
+
+      100% {
+        transform: rotate(360deg);
+      }
     }
+
     .message {
       font-size: 1.125rem;
       font-weight: 600;
       margin-bottom: 1rem;
       color: rgb(244 244 245);
     }
+
     .fallback {
       margin-top: 1.5rem;
       font-size: 0.875rem;
       color: rgb(161 161 170);
     }
+
     .fallback a {
       color: rgb(150 112 233);
       text-decoration: none;
       transition: color 0.2s ease;
     }
+
     .fallback a:hover {
       color: rgb(196 181 253);
     }
   </style>
 </head>
+
 <body>
   <div class="container">
     <div class="spinner"></div>
@@ -80,101 +94,45 @@
   </div>
 
   <script>
-    // Add immediate visual feedback
-    document.addEventListener('DOMContentLoaded', function() {
-      console.log('SideStore Open: DOM loaded, script executing');
-      
-      // Handle /open routing with different parameters
+    document.addEventListener('DOMContentLoaded', function () {
       const searchParams = new URLSearchParams(window.location.search);
       const messageElement = document.querySelector('.message');
-      
-      console.log('SideStore Open Page: Processing URL parameters', Object.fromEntries(searchParams));
-      console.log('SideStore Open: Current URL:', window.location.href);
-      
-      // Add a small delay to allow logs to be visible and add visual feedback
-      const executeWithDelay = (action, delay = 500) => {
-        console.log(`SideStore Open: Will execute action in ${delay}ms`);
-        setTimeout(action, delay);
-      };
-      
-      // Check for 'source' parameter
+
       if (searchParams.has('source')) {
         const sourceUrl = searchParams.get('source');
         const sidestoreUrl = `sidestore://source?url=${encodeURIComponent(sourceUrl)}`;
-        
-        console.log('SideStore Open: Source parameter detected', {
-          originalUrl: sourceUrl,
-          sidestoreUrl: sidestoreUrl
-        });
-        
+
         messageElement.textContent = 'Opening source in SideStore...';
-        
-        console.log('SideStore Open: Executing redirect to sidestore://source');
-        
-        // Update address bar to show homepage URL
-        window.history.replaceState({}, '', '/');
-        
-        // Attempt to redirect to the sidestore:// URL immediately
+
         window.location.href = sidestoreUrl;
-        
-        // Fallback: redirect to homepage after 3 seconds if sidestore:// doesn't work
+
+        // Redirect to homepage after a short delay, to ensure system alert is shown
         setTimeout(() => {
-          console.log('SideStore Open: Fallback timeout reached, redirecting to homepage');
-          window.location.replace('/');
-        }, 3000);
-      } 
-      // Check for 'ipa' parameter
+          window.location.href = '/';
+        }, 500);
+      }
       else if (searchParams.has('ipa')) {
         const ipaUrl = searchParams.get('ipa');
-        
-        console.log('SideStore Open: IPA parameter detected', { ipaUrl: ipaUrl });
-        
-        // Check if the URL ends with .ipa extension
         if (ipaUrl.toLowerCase().endsWith('.ipa')) {
           const sidestoreUrl = `sidestore://install?url=${encodeURIComponent(ipaUrl)}`;
-          
-          console.log('SideStore Open: Valid IPA URL, redirecting', {
-            originalUrl: ipaUrl,
-            sidestoreUrl: sidestoreUrl
-          });
-          
+
           messageElement.textContent = 'Installing IPA in SideStore...';
-          
-          console.log('SideStore Open: Executing redirect to sidestore://install');
-          
-          // Update address bar to show homepage URL
-          window.history.replaceState({}, '', '/');
-          
-          // Attempt to redirect to the sidestore:// URL immediately
+
           window.location.href = sidestoreUrl;
-          
-          // Fallback: redirect to homepage after 3 seconds if sidestore:// doesn't work
+
+          // Redirect to homepage after a short delay, to ensure system alert is shown
           setTimeout(() => {
-            console.log('SideStore Open: Fallback timeout reached, redirecting to homepage');
-            window.location.replace('/');
-          }, 3000);
-        } else {
-          // Invalid .ipa URL (doesn't end with .ipa), redirect to homepage
-          console.log('SideStore Open: Invalid IPA URL (no .ipa extension), redirecting to homepage', { ipaUrl: ipaUrl });
-          messageElement.textContent = 'Invalid IPA URL, redirecting...';
-          
-          executeWithDelay(() => {
-            console.log('SideStore Open: Executing redirect to homepage (invalid IPA)');
-            window.location.replace('/');
-          });
+            window.location.href = '/';
+          }, 500);
+        } else { 
+          window.location.href = '/';
         }
-      } 
-      // No valid parameters provided, redirect to homepage
+      }
       else {
-        console.log('SideStore Open: No valid parameters found, redirecting to homepage');
-        messageElement.textContent = 'No valid parameters, redirecting...';
-        
-        executeWithDelay(() => {
-          console.log('SideStore Open: Executing redirect to homepage (no params)');
-          window.location.replace('/');
-        });
+        window.location.href = '/';
       }
     });
   </script>
 </body>
+
 </html>


### PR DESCRIPTION
- Support `/open?source=xxx -> sidestore://source?url=xxx`
- Support `/open?ipa=xxx.ipa -> sidestore://install?url=xxx.ipa with extension validation`
- Create themed /open page matching site design

https://github.com/user-attachments/assets/bfb72553-71af-4ad5-bc70-8e3c51c91767

https://github.com/user-attachments/assets/fdfb3b11-df93-4e93-84f9-87485158c7aa

https://github.com/user-attachments/assets/1c9f5285-5185-44ba-bfbd-67778009ab6a


