### PR TITLE
Some Fixes with App Marquee, GitHub pushes and Activity Log Timestamps!

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -192,7 +192,7 @@ const repoItem = `<a style="--custom-index:{{index}}" href="{{url}}" target="_bl
       if (dateSpan == 0) set('just now');
       else if (dateSpan == 1) set('a minute ago');
       else if (dateSpan <= 60) set(`${dateSpan} minutes ago`);
-      else if (dateSpan / 60 == 1) set('an hour ago');
+      else if (Math.round(dateSpan / 60) == 1) set('an hour ago');
       else if (dateSpan / 60 <= 24) set(`${Math.round(dateSpan / 60)} hours ago`);
       else if (dateSpan / 60 <= 48) set('yesterday');
       else if (dateSpan / 60 <= 24 * 365) set(`${Math.round(dateSpan / 60 / 24)} days ago`);

--- a/src/index.js
+++ b/src/index.js
@@ -205,7 +205,7 @@ const repoItem = `<a style="--custom-index:{{index}}" href="{{url}}" target="_bl
       let glink = (id, type) => `<a class="glink" target="_blank" href="${`${url(i.data.repo.url)}/${type}/${id}`}">#${id}</a>`;
 
       let text = `<a class="glink" href="${url(i.data.actor.url)}">${i.data.actor.login}</a> `;
-      if (i.event == 'commit') text += `pushed ${i.data.commits} commit${i.data.commits > 1 ? 's' : ''}`;
+      if (i.event == 'commit') text += `pushed changes`;
       if (i.event == 'issue_comment') text += `commented on issue ${glink(i.data.issueID, 'issues')}`;
       if (i.event == 'pull_comment') text += `commented on pull request ${glink(i.data.pullID, 'pull')}`;
       if (i.event == 'pull_request') text += ` ${i.data.action} pull request ${glink(i.data.pullID, 'pull')}`;

--- a/tools/update_apps.mjs
+++ b/tools/update_apps.mjs
@@ -16,7 +16,7 @@ const additions = [
   {
    name: 'MeloNX',
    desc: 'A Nintendo Switch Emulator for iOS / iPadOS devices on 15.0+.',
-   iconURL: 'https://git.ryujinx.app/melonx/emu/-/raw/XC-ios-ht/src/MeloNX/MeloNX/Assets/Assets.xcassets/AppIcon.appiconset/nxgradientpng.png?ref_type=heads'
+   iconURL: 'https://git.ryujinx.app/projects/MeloNX/raw/branch/XC-ios-ht/src/MeloNX/MeloNX/Assets/Assets.xcassets/AppIcon.appiconset/nxgradientpng.png?ref_type=heads'
   },
 ];
 

--- a/tools/update_apps.mjs
+++ b/tools/update_apps.mjs
@@ -16,7 +16,8 @@ const additions = [
   {
    name: 'MeloNX',
    desc: 'A Nintendo Switch Emulator for iOS / iPadOS devices on 15.0+.',
-   iconURL: 'https://git.ryujinx.app/projects/MeloNX/raw/branch/XC-ios-ht/src/MeloNX/MeloNX/Assets/Assets.xcassets/AppIcon.appiconset/nxgradientpng.png?ref_type=heads'
+   iconURL: 'https://git.ryujinx.app/projects/MeloNX/raw/branch/XC-ios-ht/src/MeloNX/MeloNX/Assets/Assets.xcassets/AppIcon.appiconset/nxgradientpng.png?ref_type=heads',
+   useCustomUserAgent: true
   },
 ];
 
@@ -127,6 +128,7 @@ const outFolder = path.join(__dirname, '../src/assets/apps_data/');
   console.log(`✨ Processing ${additions.length} custom additions...`);
   for (const app of additions) {
     const { name, desc, iconURL } = app;
+    const useCustomUserAgent = app.useCustomUserAgent || false
     
     if (!name || !desc) {
       console.log(`🚫 Skipping custom app - missing name or desc`);
@@ -144,7 +146,7 @@ const outFolder = path.join(__dirname, '../src/assets/apps_data/');
         console.log(`🖼️  Downloading icon for custom app ${name}...`);
         const file = await fetch(iconURL, {
           headers: {
-            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36',
+            'User-Agent': useCustomUserAgent ? '(SideStore Website Icon Downloader)' : 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36',
           },
         });
         const buffer = await file.arrayBuffer();


### PR DESCRIPTION
Alright! uhhh so ignoring my bad code probably.
This PR does the following
- Replaces commit count (it would show `null commit`) to just pushed changes because GitHub decided to randomly remove that because why not or something like that probably
- Changes an hour ago on the GitHub activity log to rounding near the hour, otherwise if it was past 1 hour but closer to 1 hour than 2 hours it would display `1 hours ago`
- Fix the location of MeloNX icon path
- Add custom user-agent for custom icons when downloading them during the build step. Anubis would get in the way if we had a normal browser string